### PR TITLE
Sometimes fails on create temporary directory

### DIFF
--- a/instant_mongo/instant_mongo.py
+++ b/instant_mongo/instant_mongo.py
@@ -39,6 +39,7 @@ class InstantMongoDB:
         self.mongo_uri = None
         self._port_guard = None
         self._temp_dir = None
+        self._mongodb_process = None
 
         # figure out self.data_dir
         if data_dir:

--- a/instant_mongo/instant_mongo.py
+++ b/instant_mongo/instant_mongo.py
@@ -33,9 +33,9 @@ class InstantMongoDB:
 
     wait_timeout = 10
 
-    def __init__(self, data_parent_dir=None, data_dir=None):
+    def __init__(self, data_parent_dir=None, data_dir=None, port=None):
         self.logger = logger
-        self.port = None
+        self.port = port
         self.mongo_uri = None
         self._port_guard = None
         self._temp_dir = None

--- a/instant_mongo/instant_mongo.py
+++ b/instant_mongo/instant_mongo.py
@@ -68,7 +68,7 @@ class InstantMongoDB:
             if not self.port:
                 self._port_guard = PortGuard()
                 self.port = self._port_guard.get_available_port()
-            self.data_dir.mkdir()
+            self.data_dir.mkdir(parents=True)
             self._mongodb_process = MongoDBProcess(
                 logger=self.logger,
                 data_dir=self.data_dir,


### PR DESCRIPTION
Example of traceback:

```
Traceback (most recent call last):
  File "/path/to/venv/lib/python3.6/site-packages/instant_mongo/instant_mongo.py", line 70, in start
    self.data_dir.mkdir()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/pathlib.py", line 1227, in mkdir
    self._accessor.mkdir(self, mode)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/pathlib.py", line 390, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: "<TemporaryDirectory '/var/folders/jc/9rh8tp9518qfqym47_vysb640000gp/T/tmp0fkqz8wb.instant-mongo'>/instant-mongo-data.1061-1493364527442598"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
  File "/path/to/mytest.py", line 107, in test_mongo
    with InstantMongoDB() as im:
  File "/path/to/venv/lib/python3.6/site-packages/instant_mongo/instant_mongo.py", line 59, in __enter__
    self.start()
  File "/path/to/venv/lib/python3.6/site-packages/instant_mongo/instant_mongo.py", line 80, in start
    self.stop()
  File "/path/to/venv/lib/python3.6/site-packages/instant_mongo/instant_mongo.py", line 93, in stop
    if self._mongodb_process:
AttributeError: 'InstantMongoDB' object has no attribute '_mongodb_process'
```

If `_mongodb_process` is not setted on __init__ it will mask `FileNotFoundError` exception.